### PR TITLE
ci: gate guard-main-prs on tool.wt.published flag

### DIFF
--- a/.github/workflows/guard-main-prs.yml
+++ b/.github/workflows/guard-main-prs.yml
@@ -9,13 +9,27 @@ jobs:
   check-source:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Read published flag from pixi.toml
+        id: published
+        run: |
+          PUBLISHED=$(python3 -c "import tomllib; print(str(tomllib.load(open('pixi.toml','rb')).get('tool',{}).get('wt',{}).get('published', False)).lower())")
+          echo "value=$PUBLISHED" >> "$GITHUB_OUTPUT"
+          echo "tool.wt.published = $PUBLISHED"
+
       - name: Verify PR source is staging or patch-*
+        if: steps.published.outputs.value == 'true'
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if [[ "$HEAD_REF" == "staging" ]] || [[ "$HEAD_REF" == patch-* ]]; then
             echo "PR source '$HEAD_REF' is allowed."
           else
-            echo "::error::PRs to main must come from 'staging' or 'patch-*'. Got: '$HEAD_REF'"
+            echo "::error::Repo is published — PRs to main must come from 'staging' or 'patch-*'. Got: '$HEAD_REF'"
             exit 1
           fi
+
+      - name: Unpublished mode — any source allowed
+        if: steps.published.outputs.value != 'true'
+        run: echo "tool.wt.published is not true — allowing PRs to main from any branch."

--- a/pixi.toml
+++ b/pixi.toml
@@ -12,6 +12,7 @@ published = true
 [dependencies]
 # required for compilation
 wt-compiler = ">=0.5.2, <0.6.0"
+graphviz = "*"
 
 # required for testing
 go-yq = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,6 +3,12 @@ name = "wt-download-events"
 channels = ['https://repo.prefix.dev/ecoscope-workflows/', 'conda-forge']
 platforms = ['linux-64', 'osx-arm64', 'win-64']
 
+[tool.wt]
+# When true, PRs to `main` must come from `staging` or `patch-*` (enforced by
+# .github/workflows/guard-main-prs.yml). Set to false for repos that have not
+# cut a release yet to allow PRs directly to `main`.
+published = true
+
 [dependencies]
 # required for compilation
 wt-compiler = ">=0.5.2, <0.6.0"


### PR DESCRIPTION
## Summary
- Add `[tool.wt] published = true` marker to `pixi.toml`.
- `guard-main-prs.yml` reads the flag and only enforces the `staging`/`patch-*`-only rule when `published == true`. When the flag is `false` or missing, PRs to `main` are allowed from any branch — useful for repos that haven't shipped a release yet.
- `tag.yml`, `promote-staging.yml`, `test.yml`, and the `_*.yml` helpers are unchanged.

## Validation
Merging this into `staging` will cause the existing `staging → main` promotion PR (#32) to re-sync and exercise the updated `guard-main-prs.yml`. Expected behavior: `published=true` is read from `pixi.toml`, the source check runs, and `staging` is accepted as a valid source.

Closes #34

🤖 Generated with Claude Code